### PR TITLE
[s360-breeze-toolkit: SFI-PS3.1] Disable executable dependency caching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ timeout: 600
 # The summed length of file paths that can be signed with each signtool call. This parameter should only be relevant if you are signing a large number of files. Increasing the value may result in performance gains at the risk of potentially hitting your system's maximum command length limit. The minimum value is 0 and the maximum value is 30000. A value of 0 means that every file will be signed with an individual call to signtool.
 batch-size: 10000
 
-# A boolean value (true/false) that indicates if the dependencies for this action should be cached by GitHub or not. The default value is true. When using self-hosted runners, caches from workflow runs are stored on GitHub-owned cloud storage. A customer-owned storage solution is only available with GitHub Enterprise Server. When enabled, this option can reduce the duration of the action by at least 1 minute. More info: https://docs.github.com/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-cache-dependencies: true
+# A boolean value (true/false) that indicates if the dependencies for this action should be cached by GitHub or not. The default value is false because GitHub Actions caches are not a security boundary and these dependencies contain executable code. Only enable caching after ensuring that untrusted contributors cannot write cache entries readable by signing workflows, including through pull_request_target, workflow_run, or issue_comment workflows. When using self-hosted runners, caches from workflow runs are stored on GitHub-owned cloud storage. A customer-owned storage solution is only available with GitHub Enterprise Server. More info: https://docs.github.com/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+cache-dependencies: false
 
 # A boolean value (true/false) that controls trace logging. The default value is false.
 trace: false

--- a/action.yml
+++ b/action.yml
@@ -190,12 +190,13 @@ inputs:
     required: false
   cache-dependencies:
     description: A boolean value (true/false) that indicates if the dependencies for this action should be cached
-                 by GitHub or not. The default value is true. When using self-hosted runners, caches from workflow
-                 runs are stored on GitHub-owned cloud storage. A customer-owned storage solution is only available
-                 with GitHub Enterprise Server. When enabled, this option can reduce the duration of the action by
-                 at least 1 minute.
+                 by GitHub or not. The default value is false because GitHub Actions caches are not a security
+                 boundary and these dependencies contain executable code. Only enable caching when untrusted
+                 contributors cannot write cache entries readable by signing workflows. When using self-hosted
+                 runners, caches from workflow runs are stored on GitHub-owned cloud storage. A customer-owned
+                 storage solution is only available with GitHub Enterprise Server.
     required: false
-    default: 'true'
+    default: 'false'
   trace:
     description: A boolean value (true/false) that controls trace logging. The default value is false.
     required: false


### PR DESCRIPTION
This changes the cache-dependencies default from true to false so the action no longer restores executable dependencies from GitHub Actions caches unless a consumer explicitly opts in. The README and action input description now explain that GitHub Actions caches are not a security boundary and identify privileged workflow triggers that can make opt-in caching unsafe.

Open:
- Explicit cache-dependencies: true remains an opt-in risk until every restored executable is verified against trusted, pinned hashes and Microsoft signatures.
- Release owners should announce the default change because consumers relying on caching will see longer action runtimes.
- End-to-end signing validation requires a repository with Artifact Signing credentials and should confirm that an invocation without cache-dependencies skips all four cache steps.

Validation:
- Confirm the effective cache-dependencies input is false when omitted.
- Confirm all four cache restore steps are skipped by default.
- Confirm the ArtifactSigning module installs from PSGallery and signing completes successfully.
- Before permitting opt-in caching, add and test fail-closed integrity verification for the PowerShell module, signtool.exe, Microsoft.ArtifactSigning.Client, and sign.exe.

Security tracking: IdentityDivision/Engineering work item 3656125; finding 08d75d99-aa1b-4c7d-a9e6-73c06f4ccf1a (CWE-494).

<!-- sfi-toolkit-run-id: be2571c0-27ea-4581-9d84-a8ce1777cf6d -->
<!-- sfi-toolkit-skill: generic-remediation -->
<!-- sfi-toolkit-kpi: SFI-PS3.1 -->
<!-- s360-toolkit-attribution: {"schema":"1.1","run_id":"be2571c0-27ea-4581-9d84-a8ce1777cf6d","kpi_id":"SFI-PS3.1","program":"SFI","skill":"generic-remediation","arm":"raw","action_items":["a0f0ce42-3063-5d3b-3b47-1ff3143abdc9:4e041aa3-9a58-4dc4-afaa-b3ad811e5108"],"2.2.1":"2.2.1","plugin_channel":"prod"} -->