### PR TITLE
fix: clickonce filtering logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -229,7 +229,7 @@ runs:
         $defaultPath = $env:PSModulePath -split ';' | Select-Object -First 1
         "PSMODULEPATH=$defaultPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         
-        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.8" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "ARTIFACT_SIGNING_MODULE_VERSION=0.1.17" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "BUILD_TOOLS_NUGET_VERSION=10.0.26100.4188" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "ARTIFACT_SIGNING_NUGET_VERSION=1.0.128" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "DOTNET_SIGNCLI_NUGET_VERSION=0.9.1-beta.26227.3" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
Resolves #149 

This PR updates the underlying artifact signing module to ensure we properly filter clickonce files.